### PR TITLE
Fix duplicated user icon when positioning

### DIFF
--- a/SitumWayfinding/Classes/Positioning/PositioningViewController.swift
+++ b/SitumWayfinding/Classes/Positioning/PositioningViewController.swift
@@ -152,7 +152,11 @@ class PositioningViewController: SitumViewController, GMSMapViewDelegate, UITabl
     }
 
     func initializeViewBeforeAppearing(){
-        positionDrawer = GoogleMapsPositionDrawer(mapView: mapView)
+        if positionDrawer == nil {
+            positionDrawer = GoogleMapsPositionDrawer(mapView: mapView)
+        } else {
+            positionDrawer?.makeUserMarkerVisible(visible: false)
+        }
         let loading = NSLocalizedString("alert.loading.title",
             bundle: SitumMapsLibrary.bundle,
             comment: "Alert title when loading library")


### PR DESCRIPTION
* A reference to the marker with user position was lost when displaying the map. To avoid lose this reference we simply hide it if the marker already existed